### PR TITLE
Removed Expected text constants from test file

### DIFF
--- a/config/expected-text/tfl_expected_text.yaml
+++ b/config/expected-text/tfl_expected_text.yaml
@@ -1,0 +1,3 @@
+plan_a_journey:
+    from_text_alert: The From field is required.
+    to_text_alert: The To field is required.

--- a/helpers/file_io.py
+++ b/helpers/file_io.py
@@ -1,4 +1,9 @@
+from os import path
+from typing import Union, Any
+
 from ruamel import yaml
+
+from helpers.paths import EXPECTED
 
 
 def read_yaml_file(file_path: str) -> dict:
@@ -13,3 +18,55 @@ def read_yaml_file(file_path: str) -> dict:
     """
     with open(file_path, 'r', encoding='utf-8') as yaml_file:
         return yaml.safe_load(yaml_file)
+
+
+def dictionary_lookup(
+        dictionary: dict, main_node: str,
+        *secondary_nodes: Union[str, list, None]) -> Any:
+    """Recursive dictionary node lookup function.
+
+    Function can go as many nested nodes into the given dictionary as the given
+    number of secondary node arguments you specified. If the node you've
+    supplied doesnt exist then will return ``None``.
+
+    """
+    if secondary_nodes:
+        return dictionary_lookup(dictionary.get(main_node), *secondary_nodes)
+    return dictionary.get(main_node)
+
+
+def get_the_expected_text(
+        file_name: str, main_node: str,
+        secondary_nodes: Union[str, list, None]) -> Union[str, dict, None]:
+    """Get the expected text from the expected text yaml file.
+
+    If your given yaml file has more than 2 nested nodes then you will need to
+    use a list containing the nodes as strings to the secondary_nodes parameter
+    (see example 2 below)
+
+        Args:
+            file_name: File name of the yaml file.
+            main_node: The main node of the yaml file.
+            secondary_nodes: Additional nodes that return the expected value
+                required (can be a string or a list).
+
+        Example:
+            yaml_file_name = 'tfl_expected_text.yaml'
+            file.get_expected_text(file_name=yaml_file_name ,
+                                   node='plan_a_journey',
+                                   nodes='to_text_alert')
+
+        Example 2:
+            yaml_file_name = 'tfl_expected_text.yaml'
+            file.get_expected_text(
+                file_name=yaml_file_name, node='plan_a_journey',
+                nodes=['to_text_alert','another_nested_node'])
+
+        Return:
+            The expected text of the given nodes as a string.
+
+    """
+    expected_nodes_dict = read_yaml_file(path.join(EXPECTED, file_name))
+    if isinstance(secondary_nodes, str):
+        secondary_nodes = [secondary_nodes]  # make string into a list.
+    return dictionary_lookup(expected_nodes_dict, main_node, *secondary_nodes)

--- a/helpers/paths.py
+++ b/helpers/paths.py
@@ -10,6 +10,7 @@ ROOT = environ['VIRTUAL_ENV']
 CONFIG_DIR = path.join(ROOT, 'config')
 ENVS = path.join(CONFIG_DIR, 'envs.yaml')
 RESULTS_DIR = path.join(ROOT, 'results')
+EXPECTED = path.join(CONFIG_DIR, 'expected-text')
 
 FULL_REPORT = path.join(RESULTS_DIR, 'report.html')
 

--- a/pages/plan_a_journey.py
+++ b/pages/plan_a_journey.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from helpers.file_io import get_the_expected_text
+
 from selenium.webdriver.remote.webdriver import WebDriver, WebElement
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -38,6 +40,9 @@ class PlanJourneySection:
             By.CSS_SELECTOR, '.remove-content-container:not(.empty)'),
 
     }  # locators dict
+
+    EXPECTED_TEXT_FILE = 'tfl_expected_text.yaml'
+    MAIN_NODE = 'plan_a_journey'
 
     def _click_and_send_keys(self, element: WebElement, text: str) -> None:
         """Private method to click and send keys with the given text.
@@ -107,3 +112,15 @@ class PlanJourneySection:
     def clear_to_field_text(self):
         """clear the 'To' field text box."""
         self.driver.find_element(*self.locators['from_text_field']).clear()
+
+    def get_expected_from_alert_text(self) -> str:
+        """Get the expected alert text for the 'From' field."""
+        return get_the_expected_text(file_name=self.EXPECTED_TEXT_FILE,
+                                     main_node=self.MAIN_NODE,
+                                     secondary_nodes='from_text_alert')
+
+    def get_expected_to_alert_text(self) -> str:
+        """Get the expected alert text for the 'To' field."""
+        return get_the_expected_text(file_name=self.EXPECTED_TEXT_FILE,
+                                     main_node=self.MAIN_NODE,
+                                     secondary_nodes='to_text_alert')

--- a/tests/test_plan_a_journey_alerts.py
+++ b/tests/test_plan_a_journey_alerts.py
@@ -9,12 +9,11 @@ from pages.plan_a_journey import PlanJourneySection
 scenario = partial(scenario, '../feature/plan_a_journey_alerts.feature')
 
 DRIVER = webdriver.Chrome()
-FROM_ALERT_TEXT = "The From field is required."
-TO_ALERT_TEXT = "The To field is required."
 
 
 @fixture(scope='module')
 def suite_setup(env: dict):
+    """Setup fixture to open the page and finally close the browser."""
     DRIVER.get(env['site'])
     yield
     DRIVER.quit()
@@ -66,12 +65,12 @@ def i_click_on_the_plan_my_journey_button(env: dict):
 @then("I should see the alert 'The From field is required'")
 def i_should_see_alert_from_field_required(env: dict):
     """Assert that the 'From' alert has the expected text."""
-    assert (PlanJourneySection(
-        DRIVER, env).get_from_field_alert() == FROM_ALERT_TEXT)
+    page = PlanJourneySection(DRIVER, env)
+    assert (page.get_from_field_alert() == page.get_expected_from_alert_text())
 
 
 @then("I should see the alert 'The To field is required'")
 def i_should_see_alert_to_field_required(env: dict):
     """Assert that the 'To' alert has the expected text."""
-    assert (PlanJourneySection(
-        DRIVER, env).get_to_field_alert() == TO_ALERT_TEXT)
+    page = PlanJourneySection(DRIVER, env)
+    assert (page.get_to_field_alert() == page.get_expected_to_alert_text())


### PR DESCRIPTION
* Remove expected text constants from the pytest file
* Added get_expected_to_alert_text and get_expected_from_alert_text methods to plan_a_journey page object.
* Created a tfl_expected_text.yaml containing the alerts.
* Added read_yaml_file, get_the_expected_text and dictionary_lookup function to file_io.