### PR TITLE
Added provisioning of firefox or chrome drivers for pytest browser co…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,48 @@
 import pytest
+from selenium import webdriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from helpers.file_io import read_yaml_file
 from helpers.paths import ENVS
+
+
+def pytest_addoption(parser):
+    """Add options to use when running the tests."""
+
+    parser.addoption(
+        '--browser', dest='browser', action='store',
+        help='Specify the browser you want to use'
+    )
+
+
+def _provision_chrome():
+    """Provision Chrome driver."""
+    driver = webdriver.Chrome()
+    return driver
+
+
+def _provision_firefox():
+    """Provision Firefox driver."""
+    capabilities = DesiredCapabilities().FIREFOX
+    capabilities["marionette"] = False
+    driver = webdriver.Firefox(capabilities=capabilities)
+    return driver
 
 
 @pytest.fixture(scope='session', autouse=True)
 def env():
     """Get the environment config options."""
     yield read_yaml_file(ENVS)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def driver():
+    """Provisioning a driver based on pytest command line parameter."""
+    browsers = {
+        'chrome': _provision_chrome,
+        'firefox': _provision_firefox,
+    }
+    browser = pytest.config.option.browser
+    _driver = browsers[browser]()
+    yield _driver
+    _driver.quit()

--- a/tests/test_plan_a_journey_alerts.py
+++ b/tests/test_plan_a_journey_alerts.py
@@ -2,21 +2,17 @@ from functools import partial
 from pytest_bdd import given, then, scenario, when
 from pytest import fixture
 
-from selenium import webdriver
+from selenium.webdriver.remote.webdriver import WebDriver
 
 from pages.plan_a_journey import PlanJourneySection
 
 scenario = partial(scenario, '../feature/plan_a_journey_alerts.feature')
 
-DRIVER = webdriver.Chrome()
-
 
 @fixture(scope='module')
-def suite_setup(env: dict):
+def suite_setup(driver: WebDriver, env: dict):
     """Setup fixture to open the page and finally close the browser."""
-    DRIVER.get(env['site'])
-    yield
-    DRIVER.quit()
+    driver.get(env['site'])
 
 
 @scenario('I do not enter a station into the From field')
@@ -38,39 +34,39 @@ def test_i_do_not_enter_a_station_into_to_or_from_field(suite_setup):
 
 
 @given('I am on the TFL website')
-def i_am_on_the_tfl_website(env: dict):
+def i_am_on_the_tfl_website(driver: WebDriver, env: dict):
     """Verify I am on the correct page."""
-    if DRIVER.current_url != PlanJourneySection(DRIVER, env).url:
-        DRIVER.switch_to.window(env['site'])
+    if driver.current_url != PlanJourneySection(driver, env).url:
+        driver.switch_to.window(env['site'])
 
 
 @given("I leave the 'From' field empty")
-def i_leave_the_from_field_empty(env: dict):
+def i_leave_the_from_field_empty(driver: WebDriver, env: dict):
     """Clear the 'From' field text."""
-    PlanJourneySection(DRIVER, env).clear_from_field_text()
+    PlanJourneySection(driver, env).clear_from_field_text()
 
 
 @given("I leave the 'To' field empty")
-def i_leave_the_to_field_empty(env: dict):
+def i_leave_the_to_field_empty(driver: WebDriver, env: dict):
     """Clear the 'To' field text."""
-    PlanJourneySection(DRIVER, env).clear_to_field_text()
+    PlanJourneySection(driver, env).clear_to_field_text()
 
 
 @when("I click on the plan my journey button")
-def i_click_on_the_plan_my_journey_button(env: dict):
+def i_click_on_the_plan_my_journey_button(driver: WebDriver, env: dict):
     """Click on the 'plan_my_journey' button."""
-    PlanJourneySection(DRIVER, env).click_plan_my_journey_button()
+    PlanJourneySection(driver, env).click_plan_my_journey_button()
 
 
 @then("I should see the alert 'The From field is required'")
-def i_should_see_alert_from_field_required(env: dict):
+def i_should_see_alert_from_field_required(driver: WebDriver, env: dict):
     """Assert that the 'From' alert has the expected text."""
-    page = PlanJourneySection(DRIVER, env)
+    page = PlanJourneySection(driver, env)
     assert (page.get_from_field_alert() == page.get_expected_from_alert_text())
 
 
 @then("I should see the alert 'The To field is required'")
-def i_should_see_alert_to_field_required(env: dict):
+def i_should_see_alert_to_field_required(driver: WebDriver, env: dict):
     """Assert that the 'To' alert has the expected text."""
-    page = PlanJourneySection(DRIVER, env)
+    page = PlanJourneySection(driver, env)
     assert (page.get_to_field_alert() == page.get_expected_to_alert_text())


### PR DESCRIPTION
* Added the ability to provision either Firefox or Chrome to run the tests by using a '--browser' option for the pytest command line param.
* Amendments to the test file to reflect the driver changes.